### PR TITLE
fix permissions for tmp files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,6 +7,8 @@ fluentd_del_old_conf: false
 ssl_directory_path: "/etc/ssl_certs"
 domain_directory: "example.com"
 
+log_path: /var/log/fluent
+
 fluentd_plugins: []
 fluentd_config:
   - directive: system

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -67,9 +67,15 @@
     mode: '0755'
   when: dir_stat.stat.exists
 
+- name: Fluentd | Create tmp dir for fluentd files
+  file:
+    path: "{{ log_path }}/tmp"
+    state: directory
+    mode: 0775
+
 - name: Fluentd | Set permissions for fluentd log directory 
   file:
-    path: /var/log/fluent
+    path: "{{ log_path }}"
     owner: "_fluentd"
     group: "_fluentd"
     mode: 0775


### PR DESCRIPTION
If run role, its down because /var/log/fluent/tmp dir for .pos files creates after set permissions on fluent dir